### PR TITLE
CI: Deploy a prebuilt site

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,6 @@ before_script:
 script:
   - yarn run lint-build-infra
   - JEKYLL_ENV=production yarn run pre-jekyll
-  # This generated Jekyll content will not be served; it's just used to try to
-  # smoke out any build issues. I don't remember if there's a reason I don't do
-  # the Jekyll build locally, since all this plumbing is here, but there might
-  # be.
   - JEKYLL_ENV=production yarn run jekyll-build
   - ./bin/ci-run-integration-tests.sh
-  - ./bin/deploy.sh
+  - ./bin/ci-deploy.sh

--- a/bin/ci-deploy.sh
+++ b/bin/ci-deploy.sh
@@ -3,10 +3,12 @@
 ## Adapted from https://gist.github.com/domenic/ec8b0fc8ab45f39403dd and
 ## https://github.com/marionettejs/marionettejs.com/blob/da632860fd0e9b4437d8230d0bf3fc369164db2c/travis-runner.sh ##
 
-set -e # exit with nonzero exit code if anything fails
+set -euo pipefail
+
+jekyll_build_dir=_site
 
 echo "Content to be deployed is:"
-tree -ah content
+tree -ah "$jekyll_build_dir"
 
 # Deploy only if we push to the develop branch
 if [ "$TRAVIS_BRANCH" != "develop" ] || [ "$TRAVIS_PULL_REQUEST" != "false" ]
@@ -31,9 +33,11 @@ EOF
 
 git log -n1 --format=fuller >> ./deploy-commit-msg
 
-cd content
+cd "$jekyll_build_dir"
 git init
 git config core.excludesfile "$(pwd)/../.deploy-gitignore"
+
+touch .nojekyll
 
 # Redirect output to /dev/null to hide any sensitive credential data that
 # might otherwise be exposed.


### PR DESCRIPTION
Commit Jekyll output instead of having GitHub Pages run Jekyll.
This is necessary to allow use of a local plugin to generate
section partials.