### PR TITLE
New: Add tag pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,40 @@ yarn-error.log*
 
 # Sublime Text files
 *.sublime-*
+
+#### joe made this: http://goel.io/joe
+
+#### ruby ####
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'html-proofer', '= 3.11.1'
 
 # See https://pages.github.com/versions
 gem 'jekyll', '= 3.7.4'
+gem 'jekyll-archives', '= 2.2.1'
 gem 'jekyll-feed', '= 0.11.0'
 gem 'jekyll-redirect-from', '= 0.14.0'
 gem 'jekyll-seo-tag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,8 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
+    jekyll-archives (2.2.1)
+      jekyll (>= 3.6, < 5.0)
     jekyll-feed (0.11.0)
       jekyll (~> 3.3)
     jekyll-redirect-from (0.14.0)
@@ -95,6 +97,7 @@ PLATFORMS
 DEPENDENCIES
   html-proofer (= 3.11.1)
   jekyll (= 3.7.4)
+  jekyll-archives (= 2.2.1)
   jekyll-feed (= 0.11.0)
   jekyll-redirect-from (= 0.14.0)
   jekyll-seo-tag

--- a/content/_config.yml
+++ b/content/_config.yml
@@ -1,6 +1,7 @@
 url: "https://wabain.github.io"
 plugins:
   - jekyll-redirect-from
+  - jekyll-archives
   - jekyll-feed
   - jekyll-seo-tag
   - jekyll-sitemap
@@ -27,3 +28,12 @@ defaults:
       layout: "post"
       partial_layout: "post-partial"
       longform: true
+  - scope:
+      path: "tag"
+    values:
+      partial_layout: "tag-partial"
+jekyll-archives:
+  enabled: [tags]
+  layout: tag
+  permalinks:
+    tag: '/tag/:name/'

--- a/content/_includes/post-layout.html
+++ b/content/_includes/post-layout.html
@@ -9,7 +9,7 @@
         </div>
         <div>
             {% for tag in page.tags %}
-            #{{ tag }}
+            <a href='/tag/{{ tag | slugify: "pretty" }}'>#{{ tag }}</a>
             {% endfor %}
         </div>
     </div>

--- a/content/_includes/post-list.html
+++ b/content/_includes/post-list.html
@@ -1,0 +1,7 @@
+{% for post in include.posts %}
+<a href="{{ post.url }}" class="blog-post-link">
+    <h3>{{ post.title }}</h3>
+    <div class="blog-post-meta">{{ post.date | date: "%B %-d, %Y" }}</div>
+    <div class="blog-post-excerpt">{{ post.excerpt | strip_html }}</div>
+</a>
+{% endfor %}

--- a/content/_includes/tag-layout.html
+++ b/content/_includes/tag-layout.html
@@ -1,0 +1,8 @@
+<section data-page-meta="{{ page.title }}">
+    <div class="grid-base grid-blog">
+        <div class="grid-blog-listing">
+            <h2>Posts tagged #{{ page.title }}</h2>
+            {% include post-list.html posts=page.posts %}
+        </div>
+    </div>
+</section>

--- a/content/_layouts/tag-partial.html
+++ b/content/_layouts/tag-partial.html
@@ -1,0 +1,1 @@
+{% include tag-layout.html %}

--- a/content/_layouts/tag.html
+++ b/content/_layouts/tag.html
@@ -1,0 +1,5 @@
+---
+layout: page
+---
+
+{% include tag-layout.html %}

--- a/content/_plugins/archives_frontmatter.rb
+++ b/content/_plugins/archives_frontmatter.rb
@@ -1,0 +1,19 @@
+module ArchivesFrontmatter
+  class ArchivesFrontmatterGenerator < Jekyll::Generator
+    safe true
+    priority :low
+
+    def generate(site)
+      site.pages.each do |page|
+        # Hack: jekyll-archives doesn't look up YAML frontmatter
+        if page.is_a?(Jekyll::Archives::Archive) && page.data.default_proc.nil?
+          Jekyll.logger.debug "Archives data:", "Set frontmatter defaults for #{page.relative_path}"
+
+          page.data.default_proc = proc do |_, key|
+            site.frontmatter_defaults.find(page.relative_path, page.type, key)
+          end
+        end
+      end
+    end
+  end
+end

--- a/content/_plugins/partials.rb
+++ b/content/_plugins/partials.rb
@@ -10,20 +10,20 @@ module Partials
       site.pages.each do |page|
         fpath = File.join(partials.directory, page.dir, page.name)
 
-        Jekyll.logger.debug "Generating partial:", fpath
+        Jekyll.logger.debug "Partials:", "Generating from page #{page.relative_path}"
         partials.docs << PartialDocument.new(page, fpath, {
           :site => partials.site,
           :collection => partials
         })
       end
 
-      site.collections.each do |name, collection|
+      site.collections.each do |collection_name, collection|
         collection.docs.each do |doc|
           # For posts, this can give paths like _section-partial/_posts/... or
           # _section-partial/_drafts/..., but that doesn't seem to cause any harm
           fpath = File.join(partials.directory, doc.relative_path)
 
-          Jekyll.logger.debug "Generating partial:", fpath
+          Jekyll.logger.debug "Partials:", "Generating from #{collection_name} #{doc.relative_path}"
           partials.docs << PartialDocument.new(doc, fpath, {
             :site => partials.site,
             :collection => partials
@@ -47,6 +47,13 @@ module Partials
         self.content = target.content
       else
         raise ArgumentError, "unexpected partial target #{target}"
+      end
+
+      # Greedily copy across template-defined attributes
+      if defined? target.class::ATTRIBUTES_FOR_LIQUID
+        target.class::ATTRIBUTES_FOR_LIQUID.each do |attrib|
+          @data[attrib] = target.send(attrib)
+        end
       end
 
       @url = "/section-partial" + target.url

--- a/content/blog.html
+++ b/content/blog.html
@@ -10,13 +10,7 @@ nav_priority: 2
             <h2>Blog</h2>
         </div>
         <div class="grid-blog-listing">
-            {% for post in site.posts %}
-            <a href="{{ post.url }}" class="blog-post-link">
-                <h3>{{ post.title }}</h3>
-                <div class="blog-post-meta">{{ post.date | date: "%B %-d, %Y" }}</div>
-                <div class="blog-post-excerpt">{{ post.excerpt | strip_html }}</div>
-            </a>
-            {% endfor %}
+            {% include post-list.html posts=site.posts %}
         </div>
     </div>
 </section>


### PR DESCRIPTION
Currently these are only reachable from individual posts. Unlike
posts, they are hit in the navigation tests; it's not obvious
whether or not this is desirable.