### PR TITLE
CI: Use GH_BOT_TOKEN to set labels on PRs

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -197,6 +197,7 @@ jobs:
           STATUS: ${{ job.status }}
           PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         run: |
           pr="$(bin/ci-evaluate-pr.sh)"
 
@@ -249,7 +250,7 @@ jobs:
         continue-on-error: true
         env:
           PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         run: bin/ci-update-pr-label.sh "$PR_NUMBER" del merge-pending
 
       # For workflow_dispatch events there's no obvious indicator of a failure

--- a/bin/ci-update-pr-label.sh
+++ b/bin/ci-update-pr-label.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 #   bin/ci-update-pr-label.sh 100 add some-label
 #   bin/ci-update-pr-label.sh 101 del some-label
 #
-# Expected variables: GH_TOKEN, repository-level variables GITHUB_*
+# Expected variables: GH_BOT_TOKEN, repository-level variables GITHUB_*
 
 pr_number="${1:-}"
 action="${2:-}"
@@ -26,7 +26,7 @@ case "$#:$action" in
     echo "POST to $url with $params"
 
     curl --silent --show-error --fail -XPOST \
-        -H "Authorization: token $GH_TOKEN" \
+        -H "Authorization: token $GH_BOT_TOKEN" \
         -H 'Accept: application/vnd.github.v3+json' \
         "$url" -d "$params"
 
@@ -44,7 +44,7 @@ case "$#:$action" in
     echo "DELETE from $url"
 
     curl --silent --show-error --fail -XDELETE \
-        -H "Authorization: token $GH_TOKEN" \
+        -H "Authorization: token $GH_BOT_TOKEN" \
         -H 'Accept: application/vnd.github.v3+json' \
         "$url"
 


### PR DESCRIPTION
Using the standard github token seems to cause permission errors when
triggered by another user's action — e.g., dependabot. This may be
related to forking but it's unclear.