### PR TITLE
CI: Revert to using GH_TOKEN for label update

### DIFF
--- a/.github/workflows/check-merge-deploy.yml
+++ b/.github/workflows/check-merge-deploy.yml
@@ -100,7 +100,6 @@ jobs:
           RUN_BASE_SHA: ${{ steps.resolve.outputs.base_sha }}
 
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
         run: |
           pr="$(bin/ci-evaluate-pr.sh)"
 
@@ -169,5 +168,5 @@ jobs:
         continue-on-error: true
         env:
           PR_NUMBER: ${{ steps.resolve.outputs.pr_number }}
-          GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: bin/ci-update-pr-label.sh "$PR_NUMBER" del merge-pending

--- a/bin/ci-update-pr-label.sh
+++ b/bin/ci-update-pr-label.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 #   bin/ci-update-pr-label.sh 100 add some-label
 #   bin/ci-update-pr-label.sh 101 del some-label
 #
-# Expected variables: GH_BOT_TOKEN, repository-level variables GITHUB_*
+# Expected variables: GH_TOKEN, repository-level variables GITHUB_*
 
 pr_number="${1:-}"
 action="${2:-}"
@@ -26,7 +26,7 @@ case "$#:$action" in
     echo "POST to $url with $params"
 
     curl --silent --show-error --fail -XPOST \
-        -H "Authorization: token $GH_BOT_TOKEN" \
+        -H "Authorization: token $GH_TOKEN" \
         -H 'Accept: application/vnd.github.v3+json' \
         "$url" -d "$params"
 
@@ -44,7 +44,7 @@ case "$#:$action" in
     echo "DELETE from $url"
 
     curl --silent --show-error --fail -XDELETE \
-        -H "Authorization: token $GH_BOT_TOKEN" \
+        -H "Authorization: token $GH_TOKEN" \
         -H 'Accept: application/vnd.github.v3+json' \
         "$url"
 


### PR DESCRIPTION
This should be okay now because updates shouldn't be triggered by
unprivileged pull requests. The change avoids firing redundant PR
update jobs to reach steady state.