### PR TITLE
CI: Correct usage of run-name

### DIFF
--- a/.github/workflows/after-pr-build.yml
+++ b/.github/workflows/after-pr-build.yml
@@ -1,4 +1,5 @@
 name: Check merge and deploy after PR build or push to develop
+run-name: Check merge and deploy eligibility after run ${{ github.event.workflow_run.html_url }}
 on:
   workflow_run:
     workflows: ["Build and test"]
@@ -8,7 +9,6 @@ jobs:
   # When triggered by pull request build
   check-pr-merge-deploy:
     name: Check merge and deploy eligibility for pull request workflow run
-    run-name: Check merge and deploy eligibility for pull request run ${{ github.event.workflow_run.html_url }}
 
     # Assert there is a single pull request associated with the payload—I think that should be
     # the case for the pull_request event type
@@ -51,7 +51,6 @@ jobs:
   # When triggered by push to develop branch
   check-post-push-deploy:
     name: Check deploy eligibility for develop build
-    run-name: Check deploy eligibility for develop build ${{ github.event.workflow_run.html_url }}
 
     # Assert there is a single pull request associated with the payload—I think that should be
     # the case for the pull_request event type

--- a/.github/workflows/after-pr-meta-action.yml
+++ b/.github/workflows/after-pr-meta-action.yml
@@ -1,4 +1,5 @@
 name: Check merge and deploy on PR update
+run-name: "Check  merge and deploy on PR update (#${{ github.event.pull_request.number }})"
 on:
   pull_request_target:
     types: [labeled, ready_for_review]
@@ -9,7 +10,6 @@ on:
 jobs:
   workflow-state:
     name: Check validation state for pull request
-    run-name: "Check validation state for pull request #${{ github.event.pull_request.number }}"
     runs-on: ubuntu-22.04
 
     # Run on push only when the push is to the develop branch
@@ -49,7 +49,6 @@ jobs:
 
   check-merge-deploy:
     name: Check merge and deploy eligibility
-    run-name: "Check merge and deploy eligibility for #${{ github.event.pull_request.number }}"
 
     needs: [workflow-state]
 


### PR DESCRIPTION
This is supposed to be a per-workflow attribute, but an error wasn't generated for it being attached to the run until the workflow was actually executed.