### PR TITLE
CI: Ensure called workflow inherits secrets

### DIFF
--- a/.github/workflows/after-pr-build.yml
+++ b/.github/workflows/after-pr-build.yml
@@ -19,6 +19,7 @@ jobs:
       github.event.workflow_run.pull_requests[1] == null
 
     uses: ./.github/workflows/merge-deploy.yml
+    secrets: inherit
 
     with:
       workflow_run_id: ${{ github.event.workflow_run.id }}
@@ -60,6 +61,7 @@ jobs:
       github.event.workflow_run.head_branch == 'refs/heads/develop'
 
     uses: ./.github/workflows/merge-deploy.yml
+    secrets: inherit
 
     with:
       workflow_run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/after-pr-meta-action.yml
+++ b/.github/workflows/after-pr-meta-action.yml
@@ -55,6 +55,7 @@ jobs:
     if: needs.workflow-state.outputs.workflow_run_conclusion == 'success'
 
     uses: ./.github/workflows/merge-deploy.yml
+    secrets: inherit
 
     with:
       workflow_run_id: ${{ fromJSON(needs.workflow-state.outputs.workflow_run_id) }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -128,7 +128,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           dependencies: |
             tree
-            jq
             bundler
             geckodriver
 


### PR DESCRIPTION
I thought the called workflow would get its own repository secrets automatically, but it looks like it doesn't.