### PR TITLE
deps(dev): bump sass-loader to 13.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "postcss-loader": "^7.1.0",
     "prettier": "^2.8.8",
     "sass": "^1.63.3",
-    "sass-loader": "^12.4.0",
+    "sass-loader": "^13.3.2",
     "selenium-webdriver": "^4.10.0",
     "style-loader": "^3.3.3",
     "stylelint": "^14.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ devDependencies:
     specifier: ^1.63.3
     version: 1.63.3
   sass-loader:
-    specifier: ^12.4.0
-    version: 12.4.0(sass@1.63.3)(webpack@5.87.0)
+    specifier: ^13.3.2
+    version: 13.3.2(sass@1.63.3)(webpack@5.87.0)
   selenium-webdriver:
     specifier: ^4.10.0
     version: 4.10.0
@@ -4722,13 +4722,14 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
 
-  /sass-loader@12.4.0(sass@1.63.3)(webpack@5.87.0):
-    resolution: {integrity: sha512-7xN+8khDIzym1oL9XyS6zP6Ges+Bo2B2xbPrjdMHEYyV3AQYhd/wXeru++3ODHF0zMjYmVadblSKrPrjEkL8mg==}
-    engines: {node: '>= 12.13.0'}
+  /sass-loader@13.3.2(sass@1.63.3)(webpack@5.87.0):
+    resolution: {integrity: sha512-CQbKl57kdEv+KDLquhC+gE3pXt74LEAzm+tzywcA0/aHZuub8wTErbjAoNI57rPUWRYRNC5WUnNl8eGJNbDdwg==}
+    engines: {node: '>= 14.15.0'}
     peerDependencies:
       fibers: '>= 3.1.0'
-      node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+      node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
       sass: ^1.3.0
+      sass-embedded: '*'
       webpack: ^5.0.0
     peerDependenciesMeta:
       fibers:
@@ -4737,8 +4738,9 @@ packages:
         optional: true
       sass:
         optional: true
+      sass-embedded:
+        optional: true
     dependencies:
-      klona: 2.0.6
       neo-async: 2.6.2
       sass: 1.63.3
       webpack: 5.87.0(webpack-cli@5.1.4)


### PR DESCRIPTION
Doing this manually to reconcile the pending dependabot update after migrating to pnpm.